### PR TITLE
Longevity and Braveness

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ AlgoRealm, only generous heart will ever rule over Algorand. (by cusma)
 Usage:
   algorealm.py poem
   algorealm.py dynasty [--test]
+  algorealm.py longevity (--crown | --sceptre) [--test]
+  algorealm.py braveness (--crown | --sceptre) [--test]
   algorealm.py claim-majesty (--crown | --sceptre) <majesty-name> <microalgos> [--test]
   algorealm.py claim-card
   algorealm.py buy-order <microalgos> [--notify]
@@ -74,6 +76,8 @@ Usage:
 Commands:
   poem             AlgoRealm's poem.
   dynasty          Print the glorious dynasty of AlgoRealm's Majesties.
+  longevity        Print AlgoRealm's Majesties longevity.
+  braveness        Print AlgoRealm's Majesties braveness.
   claim-majesty    Claim the Crown of Entropy or the Sceptre of Proof, become Majesty of Algorand.
   claim-card       Brake the spell and claim the AlgoRealm Card by AlgoWorld.
   buy-order        Place an order for the AlgoRealm Card.
@@ -91,7 +95,7 @@ Options:
 > In case you want to give a try, you can play AlgoRealm on TestNet adding `-t`
 > to CLI commands.
 
-### 3. AlgoRealm Dynasty
+### 3. AlgoRealm Dynasty, Longevity and Braveness
 
 Who are the Majesties of the Algorand realm?
 
@@ -140,6 +144,56 @@ on Block: 14989913 donating: 4 microALGOs to the Rewards Pool.
 🪄 nullun claimed the Sceptre of Proof
 on Block: 14989913 donating: 4 microALGOs to the Rewards Pool.
 ```
+
+4. Which was the longest lasting Majesty?
+```shell
+$ python3 algorealm.py longevity --crown
+```
+
+```
+   *** 👑 RANDOMIC MAJESTY LONGEVITY ***
+
++--------------------+--------------------+
+|    Majesty Name    | Longevity (blocks) |
++--------------------+--------------------+
+| MillionAlgosFather |      5768768       |
+|       nullun       |      3366046       |
+|     jkbishbish     |      1357847       |
+|        Matt        |      1248429       |
+|      renangeo      |       416539       |
+|        👑🅿️        |       158346       |
+|        tmc         |       53895        |
+| MillionAlgosFather |       32978        |
+|       nullun       |        3369        |
++--------------------+--------------------+
+```
+
+5. Who is the bravest Majesty of all time?
+```shell
+$ python3 algorealm.py braveness --crown
+```
+
+```
+*** 👑 RANDOMIC MAJESTY BRAVENESS ***
+
++--------------------+-----------+
+|    Majesty Name    | Braveness |
++--------------------+-----------+
+|      renangeo      |   7.824   |
+| MillionAlgosFather |   4.605   |
+|        👑🅿️        |   1.609   |
+|     jkbishbish     |     1     |
+|        tmc         |   0.405   |
+|       nullun       |   0.288   |
+|       nullun       |    0.0    |
+| MillionAlgosFather |    0.0    |
+|        Matt        |    0.0    |
++--------------------+-----------+
+```
+
+> Braveness is based on the relative gorwth of donation amounts (`d'`, `d`):
+>
+> `braveness = ln(d') - ln(d)`
 
 ### 4. Claim the Crown of Entropy or the Sceptre of Proof
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "black"
-version = "22.10.0"
+version = "22.12.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -75,7 +75,7 @@ python-versions = "*"
 
 [[package]]
 name = "pathspec"
-version = "0.10.2"
+version = "0.10.3"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
@@ -83,19 +83,33 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.5.4"
+version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.9.29)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.4)", "sphinx (>=5.3)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.5)", "sphinx (>=5.3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
+
+[[package]]
+name = "prettytable"
+version = "3.5.0"
+description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+wcwidth = "*"
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "pytest-lazy-fixture"]
 
 [[package]]
 name = "py-algorand-sdk"
-version = "1.20.1"
+version = "1.20.2"
 description = "Algorand SDK in Python"
 category = "main"
 optional = false
@@ -145,10 +159,18 @@ category = "dev"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "05926e82d4f7483312cd284ec6467857bdd935dbdd66ff52b5a3573867adae85"
+content-hash = "fe2b504c5c1fda1a1b8ae6b9eb23fbe56a89d2f4b317c984338f9f07789b7694"
 
 [metadata.files]
 black = []
@@ -286,6 +308,7 @@ mypy-extensions = [
 ]
 pathspec = []
 platformdirs = []
+prettytable = []
 py-algorand-sdk = []
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -308,3 +331,4 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+wcwidth = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,11 @@ license = "MIT"
 python = "^3.10"
 docopt = "^0.6.2"
 msgpack = "^1.0.4"
-py-algorand-sdk = "^1.20.1"
+py-algorand-sdk = "^1.20.2"
+prettytable = "^3.5.0"
 
 [tool.poetry.dev-dependencies]
-black = "^22.10.0"
+black = "^22.12.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
### Description

This PR adds two new actions to the CLI:

- `longevity` lists Majesties (either with `--crown` or `--sceptre`) sorted by reigns' longevity;
- `braveness` lists Majesties (either with `--crown` or `--sceptre`) sorted by a new braveness ranking (based on donation relative growth rate).

Additional minor refactoring of `query`. 

### Checklist

> _Please, make sure to comply with the checklist below before expecting review_

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary